### PR TITLE
Improve schedule generation and UI

### DIFF
--- a/schedule_app.py
+++ b/schedule_app.py
@@ -1,23 +1,47 @@
-# schedule_app.py (수정판)
-import streamlit as st
 import re
-from collections import defaultdict
+
+import streamlit as st
 
 st.set_page_config(page_title="스케줄 자동 생성기", layout="wide")
+
 st.title("스케줄 자동 생성기")
+st.caption("입력에 맞춰 가능한 한 균형 있게 주간 스케줄을 채워줘요.")
 
 # 요일 순서: 월 ~ 일
 DAYS = ["월", "화", "수", "목", "금", "토", "일"]
 
-st.header("요일별 필요 인원 설정")
-required = {}
-for day in DAYS:
-    required[day] = st.number_input(f"{day}요일 출근 인원", min_value=0, max_value=6, value=3, key=f"req_{day}")
+st.markdown(
+    """
+### 1) 요일별 필요 인원
+원하는 만큼 인원을 설정하면, 그 기준을 맞춰 자동으로 배치합니다.
+"""
+)
 
+with st.expander("요일별 필요 인원 설정", expanded=True):
+    cols = st.columns(7)
+    required = {}
+    for i, day in enumerate(DAYS):
+        required[day] = cols[i].number_input(
+            f"{day}", min_value=0, max_value=6, value=3, key=f"req_{day}"
+        )
 
-st.header("출근 불가 요일 입력")
-example = ""
-raw = st.text_area("", value=example, height=200)
+st.markdown(
+    """
+### 2) 출근 불가 요일 입력
+`이름 - 불가능 요일` 형식으로 적어주세요. 요일이 없는 경우 `x` 또는 공백을 사용합니다.
+"""
+)
+
+example = """11.24 일 휴무
+정환 - 월 수
+서정 - x
+수영 - 금 토
+재용 - 토
+상권 - 월 금
+승민 - 목"""
+
+raw = st.text_area("", value=example, height=220)
+
 
 # 파싱: 오른쪽에 적힌 요일들은 "출근 불가"로 해석
 def parse_input(text):
@@ -38,6 +62,7 @@ def parse_input(text):
         employees_blocked[name] = blocked
     return employees_blocked
 
+
 employees_blocked = parse_input(raw)
 
 # 사용자가 보기 좋게, 각 직원의 실제 "가능한 요일"을 계산
@@ -46,100 +71,107 @@ for name, blocked in employees_blocked.items():
     employees_available[name] = [d for d in DAYS if d not in blocked]
 
 st.subheader("가능한 요일")
-for name, avail in employees_available.items():
-    st.write(f"- {name}: 가능한 요일 → {', '.join(avail) if avail else '없음(전부 불가)'}")
+if employees_available:
+    with st.container(border=True):
+        for name, avail in employees_available.items():
+            st.write(
+                f"- {name}: 가능한 요일 → {', '.join(avail) if avail else '없음(전부 불가)'}"
+            )
+else:
+    st.info("직원 정보를 입력하면 여기에서 확인할 수 있어요.")
 
 # 스케줄 생성 로직
-MIN_DAYS = 3
+MIN_TARGET = 3
+SECONDARY_TARGET = 2
 MAX_DAYS = 4
 
-def generate_schedule(employees_available, required):
-    # 초기화
+
+def attempt_schedule(employees_available, required, min_days):
+    """그리디하게 스케줄을 생성하고, 모든 직원이 min_days 이상 채웠는지 반환."""
+
     schedule = {d: [] for d in DAYS}
     remaining = required.copy()
     assigned_count = {e: 0 for e in employees_available}
 
-    # 직원별 가용일 수가 적은 사람부터 처리 (harder first)
-    employees_sorted = sorted(employees_available.keys(), key=lambda e: len(employees_available[e]))
+    employees_sorted = sorted(
+        employees_available.keys(), key=lambda e: len(employees_available[e])
+    )
 
-    # 1) 가능한 경우: **각 직원이 최소 MIN_DAYS** 가 되도록 시도
-    # 직원별로 가능한 날 중에서 아직 필요 인원이 남아있는 날에 배치 (앞에서부터)
+    # 1) 최소 일수 우선 배정 (남은 필요 인원이 많은 요일을 먼저 소진)
     for e in employees_sorted:
-        for day in DAYS:
-            if assigned_count[e] >= MIN_DAYS:
+        prefer_days = sorted(
+            [d for d in DAYS if d in employees_available[e]],
+            key=lambda d: remaining[d],
+            reverse=True,
+        )
+        for day in prefer_days:
+            if assigned_count[e] >= min_days:
                 break
-            if day in employees_available[e] and remaining[day] > 0:
+            if remaining[day] > 0:
                 schedule[day].append(e)
                 assigned_count[e] += 1
                 remaining[day] -= 1
 
-    # 2) MIN 보장 후, 남은 자리를 채우되 **근무가 적은 직원 우선**, 최대 MAX_DAYS 까지
-    # 반복: 각 요일에 대해 아직 남은 자리 있으면 가능한 직원 리스트에서 할당
-    # 직원 선택 우선순위: assigned_count 적은 순, 그리고 그날 가능해야 함, 그리고 < MAX_DAYS
+    # 2) 남은 자리 채우기 (근무 적은 직원 우선)
     for day in DAYS:
         while remaining[day] > 0:
-            # 후보: 가능한 직원 중 아직 MAX_DAYS 미만이고 그날 가능한 사람
-            candidates = [e for e in employees_available if day in employees_available[e] and assigned_count[e] < MAX_DAYS and e not in schedule[day]]
+            candidates = [
+                e
+                for e in employees_available
+                if day in employees_available[e]
+                and assigned_count[e] < MAX_DAYS
+                and e not in schedule[day]
+            ]
             if not candidates:
-                # 더 이상 배치 불가
                 break
-            # 선택: 근무가 적은 사람 우선 (균형 맞추기)
             candidates.sort(key=lambda x: assigned_count[x])
             pick = candidates[0]
             schedule[day].append(pick)
             assigned_count[pick] += 1
             remaining[day] -= 1
 
-    # 3) 조건 충족 검사: 모든 직원이 MIN_DAYS 이상인지 확인
-    all_min_ok = all(assigned_count[e] >= MIN_DAYS for e in employees_available)
+    success = all(assigned_count[e] >= min_days for e in employees_available)
+    return schedule, assigned_count, success
 
-    # 4) 만약 MIN 조건을 모두 만족하지 못하면 **fallback**: MIN 조건 무시하고 단순 그리디 배치(최소한 required 채우기)
-    if not all_min_ok:
-        # 재초기화
-        schedule = {d: [] for d in DAYS}
-        remaining = required.copy()
-        assigned_count = {e: 0 for e in employees_available}
 
-        # 간단한 그리디: 요일 순서대로, 가능한 직원 중 근무 적은 사람 우선 배정(<=MAX_DAYS)
-        for day in DAYS:
-            while remaining[day] > 0:
-                candidates = [e for e in employees_available if day in employees_available[e] and assigned_count[e] < MAX_DAYS and e not in schedule[day]]
-                if not candidates:
-                    break
-                candidates.sort(key=lambda x: assigned_count[x])
-                pick = candidates[0]
-                schedule[day].append(pick)
-                assigned_count[pick] += 1
-                remaining[day] -= 1
+def generate_schedule(employees_available, required):
+    # 1차: 전원 3일 이상 목표
+    schedule, assigned_count, success = attempt_schedule(
+        employees_available, required, MIN_TARGET
+    )
 
-    # 최종: 반환 (schedule, assigned_count, 부족한 요일 리스트)
+    if not success:
+        # 2차: 전원 2일 이상 목표로 재시도
+        schedule, assigned_count, _ = attempt_schedule(
+            employees_available, required, SECONDARY_TARGET
+        )
+
     unmet = [d for d in DAYS if len(schedule[d]) < required[d]]
-    return schedule, assigned_count, unmet
+    return schedule, assigned_count, unmet, success
 
-if st.button("스케줄 생성"):
+
+if st.button("스케줄 생성", type="primary"):
     if not employees_available:
         st.error("직원 정보가 없습니다. 입력을 확인하세요.")
     else:
-        schedule, assigned_count, unmet = generate_schedule(employees_available, required)
+        schedule, assigned_count, unmet, min3_success = generate_schedule(
+            employees_available, required
+        )
 
-        # 스케줄 출력
         st.subheader("생성된 스케줄")
         output_lines = []
-        
+
         for day in DAYS:
             names = " ".join(schedule[day]) if schedule[day] else "휴무/없음"
             line = f"{day} {names}"
             output_lines.append(line)
             st.write(line)
 
-        # 🔥 복사용 텍스트 생성 (이거 없어서 안 됐던 거임!)
         copy_text = "\n".join(output_lines)
 
-        # 복사용 텍스트 영역
         st.subheader("📋 복사하기")
         st.text_area("Copy Area", copy_text, height=200, key="copy_area")
 
-        # JavaScript 버튼 (주의: 들여쓰기 절대 넣으면 안 됨 → Streamlit이 HTML로 인식 못함)
         copy_js = """
 <script>
 function copyToClipboard() {
@@ -171,11 +203,20 @@ function copyToClipboard() {
         st.markdown(copy_js, unsafe_allow_html=True)
 
         st.subheader("직원별 배정 일수")
-        for e, cnt in assigned_count.items():
-            st.write(f"- {e}: {cnt}일")
+        col1, col2 = st.columns(2)
+        with col1:
+            for e, cnt in assigned_count.items():
+                st.write(f"- {e}: {cnt}일")
+        with col2:
+            if min3_success:
+                st.success("모든 인원이 주 3일 이상 근무하도록 배치되었습니다.")
+            else:
+                st.info("3일 배치는 불가능하여, 최소 2일 이상으로 맞췄어요.")
 
         if unmet:
             for d in unmet:
-                st.error(f"{d}요일: 필요한 인원({required[d]})을 채우지 못했습니다. (배정: {len(schedule[d])})")
+                st.error(
+                    f"{d}요일: 필요한 인원({required[d]})을 채우지 못했습니다. (배정: {len(schedule[d])})"
+                )
         else:
             st.success("모든 요일의 필요 인원이 충족되었습니다.")


### PR DESCRIPTION
## Summary
- refresh the Streamlit UI with clearer sections, defaults, and styling for required counts and availability
- update scheduling logic to prioritize 3-day assignments when possible with a 2-day fallback
- add clearer schedule, copy helper, and assignment feedback to the results

## Testing
- python -m py_compile schedule_app.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69281e2256c0832c8176c176657274ff)